### PR TITLE
Add documentation for dependencies BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,50 @@
 # ServiceTalk Examples
 
-These examples are meant to demonstrate gradle and maven build file
+These examples are meant to demonstrate Gradle and Maven build file
 configuration outside of the ServiceTalk project. For a full set of
 examples see the
 [ServiceTalk Repo](https://github.com/apple/servicetalk/tree/main/servicetalk-examples).
 
-This project uses gradle to build and includes a pom.xml in the gRPC
+This project uses gradle to build and also includes a pom.xml in the gRPC
 helloworld example to demo how the ServiceTalk gRPC code generation
-maven integration works.
+Maven integration works.
+
+## ServiceTalk BOM
+The example Gradle `build.gradle` and Maven `pom.xml` include use of BOM 
+([Bill of Materials](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
+`pom` and `module` files. These files define the versions of modules which might be included as dependencies, but
+does not include module as a dependeny. Later when the module is included as a dependency the dependency is specified
+without including a version and the version specified in the BOM is used. Said another way, BOMs allow separation of
+dependency management and version management. Centralizing the management of versions to a single file 
+greatly reduces the maintenance burden for updating to new versions and improves consistency because all references to a
+dependency will use the same version.
+
+ServiceTalk includes two BOM files each with slightly different purposes; `servicetalk-bom` and 
+`servicetalk-dependencies`. The `servicetalk-bom` BOM includes version information all ServiceTalk modules; version
+selection for dependencies is done in invidiual modules. In addition to defining versions of all ServiceTalk modules 
+the versions for ServiceTalk's dependencies are also specified. The `servicetalk-dependencies` BOM should be preferred 
+whenever possible. Unless your application requires different versions of these same dependencies then using the 
+`servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
+for building and running the application. To override a specific dependency version with your application's preference 
+you can use the : 
+
+```groovy
+implementation(platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion"))
+
+// Overrides the default Netty BOM version imported by ServiceTalk with a specific version
+implementation(enforcedPlatform("io.netty:netty-bom")) {
+    version {
+        strictly '4.1.76.Final'
+    }
+}
+// Overrides the default Jackson databind version with a specific version
+implementation ("com.fasterxml.jackson.core:jackson-databind") {
+    version {
+        strictly '2.13.2.1'
+    }
+}
+```
+
+Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
+dependencies or wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external
+dependencies to be included in that constraint.

--- a/README.md
+++ b/README.md
@@ -17,19 +17,13 @@ the same version. The BOM files define the versions of modules which might be in
 include the module as a dependency. Later when the module is included as a dependency, the dependency is specified 
 without including a version and the version specified in the BOM is used.
 
-ServiceTalk includes two BOM files each with slightly different purposes; `servicetalk-bom` and 
-`servicetalk-dependencies`. The `servicetalk-bom` BOM includes version information all ServiceTalk modules; version
-selection for external non-ServiceTalk dependencies is done in individual modules. The `servicetalk-dependencies` BOM 
-extends the `servicetalk-bom` by also defining specific versions to be used for the external modules ServiceTalk depends 
-upon. Unless your application requires different versions of these same dependencies then using the 
-`servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
-or building and running the application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
-Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
-dependencies, or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external dependencies to 
-be included in that constraint.
+ServiceTalk includes two BOM files each with slightly different purposes:
+- The `servicetalk-bom` BOM includes version information for all ServiceTalk modules; version selection for external non-ServiceTalk dependencies is done in individual modules.
+- The `servicetalk-dependencies` BOM extends the `servicetalk-bom` by also defining specific versions to be used for ServiceTalk's external dependencies.
 
-To override a specific dependency version with your application's required version you can use something like the 
-following in your `build.gradle`: 
+The `servicetalk-dependencies` BOM should be preferred whenever possible. Unless your application requires different versions of these same dependencies then using the `servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used or building and running the application. Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external dependencies, or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external dependencies to be included in that constraint.
+
+To override the version of a specific dependency with your application's required version you can use something like the following in your `build.gradle`: 
 
 ```groovy
 implementation(platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion"))
@@ -43,7 +37,7 @@ implementation(enforcedPlatform("io.netty:netty-bom")) {
 // Overrides the default Jackson databind module version with a specific version
 implementation ("com.fasterxml.jackson.core:jackson-databind") {
     version {
-        strictly '2.13.2.1'
+        strictly '2.13'
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ extends the `servicetalk-bom` by also defining specific versions to be used for 
 upon. Unless your application requires different versions of these same dependencies then using the 
 `servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
 or building and running the application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
+Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
+dependencies or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external dependencies to 
+be included in that constraint.
 
 To override a specific dependency version with your application's required version you can use something like the 
 following in your `build.gradle`: 
@@ -44,7 +47,3 @@ implementation ("com.fasterxml.jackson.core:jackson-databind") {
     }
 }
 ```
-
-Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
-dependencies or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external
-dependencies to be included in that constraint.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Maven integration works.
 The example Gradle `build.gradle` and Maven `pom.xml` include use of BOM 
 ([Bill of Materials](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
 `pom` and `module` files. These files define the versions of modules which might be included as dependencies, but
-does not include module as a dependeny. Later when the module is included as a dependency the dependency is specified
+do not include module as a dependency. Later when the module is included as a dependency the dependency is specified
 without including a version and the version specified in the BOM is used. Said another way, BOMs allow separation of
 dependency management and version management. Centralizing the management of versions to a single file 
 greatly reduces the maintenance burden for updating to new versions and improves consistency because all references to a
@@ -21,12 +21,14 @@ dependency will use the same version.
 
 ServiceTalk includes two BOM files each with slightly different purposes; `servicetalk-bom` and 
 `servicetalk-dependencies`. The `servicetalk-bom` BOM includes version information all ServiceTalk modules; version
-selection for dependencies is done in invidiual modules. In addition to defining versions of all ServiceTalk modules 
-the versions for ServiceTalk's dependencies are also specified. The `servicetalk-dependencies` BOM should be preferred 
-whenever possible. Unless your application requires different versions of these same dependencies then using the 
-`servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
-for building and running the application. To override a specific dependency version with your application's preference 
-you can use the : 
+selection for dependencies is done in individual modules. The `servicetalk-dependencies` BOM extends the 
+`servicetalk-bom` by also defining specific versions to be used for the external modules ServiceTalk depends upon. 
+Unless your application requires different versions of these same dependencies then using the `servicetalk-dependencies`
+BOM is the most convenient way to ensure that a tested and supported set of modules is used or building and running the 
+application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
+
+To override a specific dependency version with your application's required version you can use something like the 
+following in your `build.gradle` : 
 
 ```groovy
 implementation(platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion"))

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ ServiceTalk gRPC code generation Maven integration works.
 ## ServiceTalk BOM
 The example Gradle `build.gradle` and Maven `pom.xml` include use of BOM 
 ([Bill of Materials](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
-`pom` and `module` files. BOM files allow separation of dependency management and version management; a BOM specifies on
-component versions, not dependencies. Centralizing the management of versions to a single file greatly reduces the 
+`pom` and `module` files. BOM files allow separation of dependency management and version management; a BOM specifies 
+only component versions, not dependencies. Centralizing the management of versions to a single file greatly reduces the 
 maintenance burden for updating to new versions and improves consistency because all references to a dependency will use 
 the same version. The BOM files define the versions of modules which might be included as dependencies, but do not 
 include the module as a dependency. Later when the module is included as a dependency, the dependency is specified 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # ServiceTalk Examples
 
 These examples are meant to demonstrate Gradle and Maven build file
-configuration outside of the ServiceTalk project. For a full set of
-examples see the
+configuration outside the ServiceTalk project. For a full set of examples see the
 [ServiceTalk Repo](https://github.com/apple/servicetalk/tree/main/servicetalk-examples).
 
-This project uses gradle to build and also includes a pom.xml in the gRPC
-`helloworld` example to demo how the ServiceTalk gRPC code generation
-Maven integration works.
+This project uses Gradle to build and also includes a Maven `pom.xml` in the gRPC `helloworld` example to demo how the 
+ServiceTalk gRPC code generation Maven integration works.
 
 ## ServiceTalk BOM
 The example Gradle `build.gradle` and Maven `pom.xml` include use of BOM 
 ([Bill of Materials](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
-`pom` and `module` files. BOM filess allow separation of dependency management and version management. Centralizing the
-management of versions to a single file greatly reduces the maintenance burden for updating to new versions and improves
-consistency because all references to a dependency will use the same version. These files define the versions of modules
-which might be included as dependencies, but do not include module as a dependency. Later when the module is included as
-a dependency the dependency is specified without including a version and the version specified in the BOM is used.
+`pom` and `module` files. BOM files allow separation of dependency management and version management; a BOM specifies on
+component versions, not dependencies. Centralizing the management of versions to a single file greatly reduces the 
+maintenance burden for updating to new versions and improves consistency because all references to a dependency will use 
+the same version. The BOM files define the versions of modules which might be included as dependencies, but do not 
+include the module as a dependency. Later when the module is included as a dependency, the dependency is specified 
+without including a version and the version specified in the BOM is used.
 
 ServiceTalk includes two BOM files each with slightly different purposes; `servicetalk-bom` and 
 `servicetalk-dependencies`. The `servicetalk-bom` BOM includes version information all ServiceTalk modules; version

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ upon. Unless your application requires different versions of these same dependen
 `servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
 or building and running the application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
 Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
-dependencies or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external dependencies to 
+dependencies, or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external dependencies to 
 be included in that constraint.
 
 To override a specific dependency version with your application's required version you can use something like the 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,28 @@ examples see the
 [ServiceTalk Repo](https://github.com/apple/servicetalk/tree/main/servicetalk-examples).
 
 This project uses gradle to build and also includes a pom.xml in the gRPC
-helloworld example to demo how the ServiceTalk gRPC code generation
+`helloworld` example to demo how the ServiceTalk gRPC code generation
 Maven integration works.
 
 ## ServiceTalk BOM
 The example Gradle `build.gradle` and Maven `pom.xml` include use of BOM 
 ([Bill of Materials](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
-`pom` and `module` files. These files define the versions of modules which might be included as dependencies, but
-do not include module as a dependency. Later when the module is included as a dependency the dependency is specified
-without including a version and the version specified in the BOM is used. Said another way, BOMs allow separation of
-dependency management and version management. Centralizing the management of versions to a single file 
-greatly reduces the maintenance burden for updating to new versions and improves consistency because all references to a
-dependency will use the same version.
+`pom` and `module` files. BOM filess allow separation of dependency management and version management. Centralizing the
+management of versions to a single file greatly reduces the maintenance burden for updating to new versions and improves
+consistency because all references to a dependency will use the same version. These files define the versions of modules
+which might be included as dependencies, but do not include module as a dependency. Later when the module is included as
+a dependency the dependency is specified without including a version and the version specified in the BOM is used.
 
 ServiceTalk includes two BOM files each with slightly different purposes; `servicetalk-bom` and 
 `servicetalk-dependencies`. The `servicetalk-bom` BOM includes version information all ServiceTalk modules; version
-selection for dependencies is done in individual modules. The `servicetalk-dependencies` BOM extends the 
-`servicetalk-bom` by also defining specific versions to be used for the external modules ServiceTalk depends upon. 
-Unless your application requires different versions of these same dependencies then using the `servicetalk-dependencies`
-BOM is the most convenient way to ensure that a tested and supported set of modules is used or building and running the 
-application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
+selection for external non-ServiceTalk dependencies is done in individual modules. The `servicetalk-dependencies` BOM 
+extends the `servicetalk-bom` by also defining specific versions to be used for the external modules ServiceTalk depends 
+upon. Unless your application requires different versions of these same dependencies then using the 
+`servicetalk-dependencies` BOM is the most convenient way to ensure that a tested and supported set of modules is used 
+or building and running the application. The `servicetalk-dependencies` BOM should be preferred whenever possible. 
 
 To override a specific dependency version with your application's required version you can use something like the 
-following in your `build.gradle` : 
+following in your `build.gradle`: 
 
 ```groovy
 implementation(platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion"))
@@ -39,7 +38,7 @@ implementation(enforcedPlatform("io.netty:netty-bom")) {
         strictly '4.1.76.Final'
     }
 }
-// Overrides the default Jackson databind version with a specific version
+// Overrides the default Jackson databind module version with a specific version
 implementation ("com.fasterxml.jackson.core:jackson-databind") {
     version {
         strictly '2.13.2.1'
@@ -48,5 +47,5 @@ implementation ("com.fasterxml.jackson.core:jackson-databind") {
 ```
 
 Using the `servicetalk-bom` may be easier when your application wishes to do more complete management of external
-dependencies or wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external
+dependencies or you wish to include ServiceTalk as an `enforcedPlatform`, but do not want the external
 dependencies to be included in that constraint.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ implementation(enforcedPlatform("io.netty:netty-bom")) {
 // Overrides the default Jackson databind module version with a specific version
 implementation ("com.fasterxml.jackson.core:jackson-databind") {
     version {
-        strictly '2.13'
+        strictly '2.13.3'
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,4 @@ servicetalkVersion=0.42.11
 
 # gRPC
 protobufGradlePluginVersion=0.8.18
-protobufVersion=3.20.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,21 +15,19 @@
 #
 # project metadata used for publications
 group=io.servicetalk
-version=0.42.0
+version=0.42.11-SNAPSHOT
 scmHost=github.com
 scmPath=servicetalk/examples
 issueManagementUrl=https://github.com/servicetalk/examples/issues
 ciManagementUrl=https://github.com/servicetalk/examples/actions
 
 # dependency versions
-servicetalkVersion=0.42.10
-log4jVersion=2.17.2
+servicetalkVersion=0.42.11-SNAPSHOT
 slf4jVersion=1.7.36
 
 jaxRsVersion=2.1.6
 jerseyVersion=2.35
 
-jacksonVersion=2.13.2.2
 openTracingVersion=0.33.0
 
 spotbugsPluginVersion=4.7.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,21 +16,9 @@
 # project metadata used for publications
 group=io.servicetalk
 version=0.42.11
-scmHost=github.com
-scmPath=servicetalk/examples
-issueManagementUrl=https://github.com/servicetalk/examples/issues
-ciManagementUrl=https://github.com/servicetalk/examples/actions
 
 # dependency versions
 servicetalkVersion=0.42.11
-slf4jVersion=1.7.36
-
-jaxRsVersion=2.1.6
-jerseyVersion=2.35
-
-openTracingVersion=0.33.0
-
-spotbugsPluginVersion=4.7.5
 
 # gRPC
 protobufGradlePluginVersion=0.8.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,14 +15,14 @@
 #
 # project metadata used for publications
 group=io.servicetalk
-version=0.42.11-SNAPSHOT
+version=0.42.11
 scmHost=github.com
 scmPath=servicetalk/examples
 issueManagementUrl=https://github.com/servicetalk/examples/issues
 ciManagementUrl=https://github.com/servicetalk/examples/actions
 
 # dependency versions
-servicetalkVersion=0.42.11-SNAPSHOT
+servicetalkVersion=0.42.11
 slf4jVersion=1.7.36
 
 jaxRsVersion=2.1.6

--- a/grpc/helloworld/build.gradle
+++ b/grpc/helloworld/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:$protobufVersion"
+    artifact = "com.google.protobuf:protoc"
   }
 
   plugins {

--- a/grpc/helloworld/build.gradle
+++ b/grpc/helloworld/build.gradle
@@ -23,14 +23,15 @@ buildscript {
 apply plugin: "com.google.protobuf"
 
 dependencies {
-  implementation platform("io.servicetalk:servicetalk-bom:$servicetalkVersion")
+  implementation(platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion"))
+
   implementation "io.servicetalk:servicetalk-annotations"
   implementation "io.servicetalk:servicetalk-grpc-netty"
   implementation "io.servicetalk:servicetalk-grpc-protoc"
   implementation "io.servicetalk:servicetalk-grpc-protobuf"
 
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  implementation "org.slf4j:slf4j-api"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }
 
 protobuf {

--- a/grpc/helloworld/pom.xml
+++ b/grpc/helloworld/pom.xml
@@ -68,7 +68,7 @@
     <dependencies>
       <dependency>
         <groupId>io.servicetalk</groupId>
-        <artifactId>servicetalk-bom</artifactId>
+        <artifactId>servicetalk-dependencies</artifactId>
         <version>${servicetalk.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/http/helloworld/build.gradle
+++ b/http/helloworld/build.gradle
@@ -15,9 +15,9 @@
  */
 
 dependencies {
-  implementation platform("io.servicetalk:servicetalk-bom:$servicetalkVersion")
+  implementation platform("io.servicetalk:servicetalk-dependencies:$servicetalkVersion")
   implementation "io.servicetalk:servicetalk-annotations"
   implementation "io.servicetalk:servicetalk-http-netty"
 
-  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }


### PR DESCRIPTION
Motivation:
None of the current documentation or examples provide guidance on using
the `servicetalk-bom` or new `servicetalk-dependencies` modules.
Modifications:
Extend examples to use the `servicetalk-dependencies` BOM and provide
documentation describing their usange and guidance on overriding the
version selection.
Result:
Improved documentation