### PR TITLE
Restore `protoc` version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,5 @@ servicetalkVersion=0.42.11
 
 # gRPC
 protobufGradlePluginVersion=0.8.18
+protobufVersion=3.21.0
 

--- a/grpc/helloworld/build.gradle
+++ b/grpc/helloworld/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc"
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
 
   plugins {


### PR DESCRIPTION
Motiviation:
The gRPC example currently fails to build due to missing version for
`protoc` executable. This version is not received from including the
`servicetalk-dependencies` BOM and must be explicitly specified in
this context.
Modifications:
Restore `protobufVersion` property and use it for version of `protoc`.
Result:
gRPC example builds correctly.